### PR TITLE
change function name to term

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -721,7 +721,7 @@ ClientHello message following the description in Section 4.1.2 of {{I-D.ietf-tls
 
 If the HelloRetryRequest message is used, the initial ClientHello and
 the HelloRetryRequest are included in the calculation of the
-Transcript-Hash. The computation of the
+transcript hash. The computation of the
 message hash for the HelloRetryRequest is done according to the description
 in Section 4.4.1 of {{I-D.ietf-tls-tls13}}.
 


### PR DESCRIPTION
"Transcript-Hash" is the name of the function. I belive it would be more appropriate to use
the "transcript hash" term here.