### PR TITLE
Describe duplication of state machines for post-handshake messages

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1368,6 +1368,15 @@ via independent state machines each of which behaves as described in {{state-mac
 For example, if a server sends a NewSessionTicket and a CertificateRequest message,
 two independent state machines will be created.
 
+As explained in the corresponding sections, sending multiple instances of messages of
+a given category without having completed earlier transmissions is allowed for some
+categories, but not for others. Specifically, a server MAY send multiple NewSessionTicket
+messages at once without awaiting ACKs for earlier NewSessionTicket first. Likewise, a
+server MAY send multiple CertificateRequest messages at once without having completed
+earlier client authentication requests before. In contrast, implementations MUST NOT
+have send KeyUpdate, NewConnectionId or RequestConnectionId message if an earlier message
+of the same type has not yet been acknowledged.
+
 Note: Except for post-handshake client authentication, which involves handshake messages
 in both directions, post-handshake messages are single-flight, and their respective state
 machines on the sender side reduce to waiting for an ACK and retransmitting the original

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1675,7 +1675,7 @@ ACKs SHOULD NOT be sent for other
 complete flights because they are implicitly acknowledged
 by the receipt of the next flight, which generally
 immediately follows the flight. As explained in {{state-machine-duplication}},
-each category of post-handshake messages (e.g. NewSessionTicket or KeyUpdate)
+each category of post-handshake messages (e.g., NewSessionTicket or KeyUpdate)
 is treated as an individual handshake. For example, a KeyUpdate sent in response
 to a KeyUpdate with update_requested does not implicitly acknowledge that message.
 Implementations MAY acknowledge the records corresponding to each transmission of

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1359,7 +1359,7 @@ DTLS 1.3 makes use of the following categories of post-handshake messages:
 
 3. NewConnectionId
 
-4. RequestionConnectionId
+4. RequestConnectionId
 
 5. Post-handshake client authentication
 
@@ -1374,7 +1374,7 @@ machines on the sender side reduce to waiting for an ACK and retransmitting the 
 message.
 
 Creating and correctly updating multiple state machines requires feedback from the handshake
-logic to the state machine layer, indicating which message belong to which state machine.
+logic to the state machine layer, indicating which message belongs to which state machine.
 For example, if a server sends multiple CertificateRequest messages and receives a Certificate
 message in response, the corresponding state machine can only be determined after inspecting the
 certificate_request_context field. Similarly, a server sending a single CertificateRequest

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1364,7 +1364,7 @@ DTLS 1.3 makes use of the following categories of post-handshake messages:
 5. Post-handshake client authentication
 
 Messages of each category can be sent independently, and reliability is established
-via independent state machines each of which behaves as described in {state-machine}.
+via independent state machines each of which behaves as described in {{state-machine}}.
 For example, if a server sends a NewSessionTicket and a CertificateRequest message,
 two independent state machines will be created.
 

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1374,7 +1374,7 @@ categories, but not for others. Specifically, a server MAY send multiple NewSess
 messages at once without awaiting ACKs for earlier NewSessionTicket first. Likewise, a
 server MAY send multiple CertificateRequest messages at once without having completed
 earlier client authentication requests before. In contrast, implementations MUST NOT
-have send KeyUpdate, NewConnectionId or RequestConnectionId message if an earlier message
+send KeyUpdate, NewConnectionId or RequestConnectionId message if an earlier message
 of the same type has not yet been acknowledged.
 
 Note: Except for post-handshake client authentication, which involves handshake messages

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1380,7 +1380,9 @@ of the same type has not yet been acknowledged.
 Note: Except for post-handshake client authentication, which involves handshake messages
 in both directions, post-handshake messages are single-flight, and their respective state
 machines on the sender side reduce to waiting for an ACK and retransmitting the original
-message.
+message. In particular, note that a RequestConnectionId message does not force the receiver
+to send a NewConnectionId message in reply, and both messages are therefore treated
+independently.
 
 Creating and correctly updating multiple state machines requires feedback from the handshake
 logic to the state machine layer, indicating which message belongs to which state machine.


### PR DESCRIPTION
As discussed in https://mailarchive.ietf.org/arch/msg/tls/Pvg2IUJAYTyQDygUBDV_D_ozRHM/, post-handshake messages should be handled via independent state machines. This PR is a first attempt to add a section to the spec explicitly mentioning this.