### PR TITLE
Clarify when you can reset the timer

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1415,7 +1415,8 @@ retransmission for handshake and not dataflow, the effect on
 congestion should be minimal.
 
 Implementations SHOULD retain the current timer value until a
-transmission without loss occurs, at which time the value may be
+message is transmitted and acknowledged without having to
+be retransmitted, at which time the value may be
 reset to the initial value.  After a long period of idleness, no less
 than 10 times the current timer value, implementations MAY reset the
 timer to the initial value.


### PR DESCRIPTION
This says to reset when you get a transmission without loss, but I actually think this is potentially too conservative and we should just reset on every "first" transmission.