### PR TITLE
Rcid excessive

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1917,8 +1917,9 @@ NewConnectionId with usage "cid_spare" containing num_cid CIDs soon as
 possible.  Endpoints MUST NOT send a RequestConnectionId message
 when an existing request is still unfulfilled; this implies that
 endpoints needs to request new CIDs well in advance.  An endpoint MAY
-ignore requests, which it considers excessive (though they MUST be
-acknowledged as usual).
+handle requests which it considers excessive by responding with
+a NewConnectionId message containing fewer than num_cid CIDs,
+including no CIDs at all.
 
 Endpoints MUST NOT send either of these messages if they did not negotiate a
 CID. If an implementation receives these messages when CIDs

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1920,7 +1920,8 @@ endpoints needs to request new CIDs well in advance.  An endpoint MAY
 handle requests, which it considers excessive, by responding with
 a NewConnectionId message containing fewer than num_cid CIDs,
 including no CIDs at all. Endpoints MAY handle an excessive number
-of RequestConnectionId messages by terminating the connection.
+of RequestConnectionId messages by terminating the connection
+using a "too_many_cids_requested" (alert number 52) alert.
 
 Endpoints MUST NOT send either of these messages if they did not negotiate a
 CID. If an implementation receives these messages when CIDs
@@ -2085,6 +2086,9 @@ registry for the ACK message, defined in {{ack-msg}}, with content type 26.
 The value for the "DTLS-OK" column is "Y".  IANA is requested to reserve
 the content type range 32-63 so that content types in this range are not
 allocated.
+
+IANA is requested to allocate "the too_many_cids_requested" alert in
+the "TLS Alerts" registry with value 52.
 
 IANA is requested to allocate two values in the "TLS Handshake Type"
 registry, defined in {{!TLS13}}, for RequestConnectionId (TBD), and

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1917,7 +1917,7 @@ NewConnectionId with usage "cid_spare" containing num_cid CIDs soon as
 possible.  Endpoints MUST NOT send a RequestConnectionId message
 when an existing request is still unfulfilled; this implies that
 endpoints needs to request new CIDs well in advance.  An endpoint MAY
-handle requests which it considers excessive by responding with
+handle requests, which it considers excessive, by responding with
 a NewConnectionId message containing fewer than num_cid CIDs,
 including no CIDs at all. Endpoints MAY handle an excessive number
 of RequestConnectionId messages by terminating the connection.
@@ -2401,4 +2401,3 @@ In addition, we would like to thank:
 # Acknowledgements
 
 We would like to thank Jonathan Hammell for his review comments.
-

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1919,7 +1919,8 @@ when an existing request is still unfulfilled; this implies that
 endpoints needs to request new CIDs well in advance.  An endpoint MAY
 handle requests which it considers excessive by responding with
 a NewConnectionId message containing fewer than num_cid CIDs,
-including no CIDs at all.
+including no CIDs at all. Endpoints MAY handle an excessive number
+of RequestConnectionId messages by terminating the connection.
 
 Endpoints MUST NOT send either of these messages if they did not negotiate a
 CID. If an implementation receives these messages when CIDs


### PR DESCRIPTION
Fix a deadlock identified by @kaduk"

This seems like it sets up a deadlock scenario.  Consider peers A and B;
A sends RequestConnectionId with num_cids=200 and B considers this
request excessive, so ACKs it but sends no NewConnectionId in response.
A is prohibited from sending another RequestConnection Id to indicate
that it really needs new CIDs, since the requested 200 have not arrived
yet; thus, B could end up not sending any NewConnectionIds even though A
is essentially blocking on getting them.  Unless "unfulfilled" is
supposed to mean "not ACKed"?