### PR TITLE
Updated example in Section 6

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1555,18 +1555,18 @@ Client                                                Server
 
                              X<-----                 Record 0
                              (lost)               ServerHello
-                                              (message_seq=1)
+                                              (message_seq=0)
                                           EncryptedExtensions
-                                              (message_seq=2)
+                                              (message_seq=1)
                                                   Certificate
-                                              (message_seq=3)
+                                              (message_seq=2)
 
 
                            <--------                 Record 1
                                             CertificateVerify
-                                              (message_seq=4)
+                                              (message_seq=3)
                                                      Finished
-                                              (message_seq=5)
+                                              (message_seq=4)
 
  Record 1                  -------->
  ACK []
@@ -1574,11 +1574,11 @@ Client                                                Server
 
                            <--------                 Record 2
                                                   ServerHello
-                                              (message_seq=1)
+                                              (message_seq=0)
                                           EncryptedExtensions
-                                              (message_seq=2)
+                                              (message_seq=1)
                                                   Certificate
-                                              (message_seq=3)
+                                              (message_seq=2)
 
  Record 2                  -------->
  Certificate

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1543,7 +1543,11 @@ the 5-tuple-based ambiguity.
 # Example of Handshake with Timeout and Retransmission
 
 The following is an example of a handshake with lost packets and
-retransmissions.
+retransmissions. Note that the client sends an empty ACK message  
+because it can only acknowledge Record 1 sent by the server once it has 
+processed messages in Record 0 needed to establish epoch 2 keys, which 
+are needed to encrypt to decrypt messages found in Record 1.  {{ack-msg}} 
+provides the necessary background details for this interaction. 
 
 ~~~
 Client                                                Server
@@ -1590,7 +1594,6 @@ Client                                                Server
 
                            <--------               Record 3
                                                     ACK [2]
-
 ~~~
 {: #dtls-msg-loss title="Example DTLS exchange illustrating message loss"}
 


### PR DESCRIPTION
Based on review from Ben:

    Section 6

    Figure 11 seems to show that the initial ServerHello has message_seq=1,
    but §5.2 says that "[t]he first message each side transmits in each
    association always has message_seq = 0". Which one is it? (A change
    here would affect all the server's messages except the final ACK.)