### PR TITLE
Added text regarding the legacy_session_id field

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1113,7 +1113,11 @@ random:
 : Same as for TLS 1.3.
 
 legacy_session_id:
-: Same as for TLS 1.3.
+: Versions of TLS and DTLS before version 1.3 supported a "session resumption" 
+feature which has been merged with pre-shared keys in version 1.3.  A client 
+which has a cached session ID set by a pre-DTLS 1.3 server SHOULD set this
+field to that value. Otherwise, it MUST be set as a zero-length vector
+(i.e., a zero-valued single byte length field).
 
 legacy_cookie:
 : A DTLS 1.3-only client MUST set the legacy_cookie field to zero length.


### PR DESCRIPTION
It is not the same as TLS 1.3, as previously stated, because DTLS 1.3 does not support the compatibility mode.