### PR TITLE
fix duplicate TLS13 ref

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1281,7 +1281,7 @@ Remarks:
    acknowledged with an ACK message.
 
 Below are several example message exchange illustrating the flight concept.
-The notational conventions from {{TLS13}} are used.
+The notational conventions from {{!TLS13}} are used.
 
 ~~~
 Client                                             Server

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1281,7 +1281,7 @@ Remarks:
    acknowledged with an ACK message.
 
 Below are several example message exchange illustrating the flight concept.
-The notational conventions from {{!RFC8446}} are used.
+The notational conventions from {{TLS13}} are used.
 
 ~~~
 Client                                             Server


### PR DESCRIPTION
I added this with naive editing that forgot we use [TLS13] as the tag for RFC 8446.