### PR TITLE
More epochs per connection (uint32 or uint64)

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -324,7 +324,7 @@ meaning of the fields is unchanged from previous TLS / DTLS versions.
     struct {
         ContentType type;
         ProtocolVersion legacy_record_version;
-        uint16 epoch = 0
+        uint32 epoch = 0
         uint48 sequence_number;
         uint16 length;
         opaque fragment[DTLSPlaintext.length];
@@ -427,22 +427,24 @@ underlying transport datagram.
 |   16 bit      |     |               |     |8-bit Seq. No. |
 |   Version     |     / Connection ID /     +-+-+-+-+-+-+-+-+
 +-+-+-+-+-+-+-+-+     |               |     |               |
-|   16 bit      |     +-+-+-+-+-+-+-+-+     |   Encrypted   |
-|    Epoch      |     |    16 bit     |     /   Record      /
-+-+-+-+-+-+-+-+-+     |Sequence Number|     |               |
+|               |     +-+-+-+-+-+-+-+-+     |   Encrypted   |
+|   32 bit      |     |    16 bit     |     /   Record      /
+|    Epoch      |     |Sequence Number|     |               |
 |               |     +-+-+-+-+-+-+-+-+     +-+-+-+-+-+-+-+-+
-|               |     |   16 bit      |
-|   48 bit      |     |   Length      |       DTLSCiphertext
-|Sequence Number|     +-+-+-+-+-+-+-+-+         Structure
-|               |     |               |         (minimal)
-|               |     |  Encrypted    |
-+-+-+-+-+-+-+-+-+     /  Record       /
-|    16 bit     |     |               |
-|    Length     |     +-+-+-+-+-+-+-+-+
-+-+-+-+-+-+-+-+-+
-|               |      DTLSCiphertext
-|               |        Structure
-/   Fragment    /          (full)
++-+-+-+-+-+-+-+-+     |   16 bit      |
+|               |     |   Length      |       DTLSCiphertext
+|               |     +-+-+-+-+-+-+-+-+         Structure
+|   48 bit      |     |               |         (minimal)
+|Sequence Number|     |  Encrypted    |
+|               |     /  Record       /
+|               |     |               |
++-+-+-+-+-+-+-+-+     +-+-+-+-+-+-+-+-+
+|    16 bit     |
+|    Length     |      DTLSCiphertext
++-+-+-+-+-+-+-+-+        Structure
+|               |          (full)
+|               |
+/   Fragment    /
 |               |
 +-+-+-+-+-+-+-+-+
 
@@ -471,12 +473,12 @@ unpacked RecordNumber structure, as shown below:
 ~~~
 %%% Record Layer
     struct {
-        uint16 epoch;
+        uint32 epoch;
         uint48 sequence_number;
     } RecordNumber;
 ~~~
 
-This 64-bit value is used in the ACK message as well as in the "record_sequence_number"
+This 80-bit value is used in the ACK message. The low order 64 bits is used in the "record_sequence_number"
 input to the AEAD function.
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
@@ -1818,7 +1820,7 @@ protocol exchange to allow identification of the correct cipher state:
      from the initial \[sender\]_application_traffic_secret_0. This may include
      handshake messages, such as post-handshake messages (e.g., a
      NewSessionTicket message).
-   * epoch value (4 to 2^16-1) is used for payloads protected using keys from
+   * epoch value (4 to 2^32-1) is used for payloads protected using keys from
      the \[sender\]_application_traffic_secret_N (N>0).
 
 Using these reserved epoch values a receiver knows what cipher state


### PR DESCRIPTION
This PR addresses #249.

Larger epoch (e.g. 32-bit) seems quite straightforward.

- It changes the DTLSPlaintext structure which is not sent on the wire.

- It changes the RecordNumber structure used in the ACK message. This should likely contain the full epoch

- It changes the 64-bit "record_sequence_number". This PR suggest the 64 low order bits of the RecordNumber.
I think it could also be set to 0x0000 || sequence_number. I don't think epoch is needed here as the keys are
different.

Note that a 32-bit epoch still limits the number of packets in a AES-GCM connection compared to what is allowed in DTLS 1.2.
2^56.6 compared to 2^64. 2^56.5 is likely enough for all use cases but epoch could also be made even larger 2^48 or 2^64.