### PR TITLE
More epochs per connection (epoch wrap)

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -598,9 +598,6 @@ epoch and keying material as the original transmission.
 Implementations MUST either abandon an association or re-key prior to
 allowing the sequence number to wrap.
 
-Implementations MUST NOT allow the epoch to wrap, but instead MUST
-establish a new association, terminating the old association.
-
 ### Reconstructing the Sequence Number and Epoch {#reconstructing}
 
 When receiving protected DTLS records, the recipient does not
@@ -1827,8 +1824,8 @@ message. Implementations that receive a record with an epoch value
 for which no corresponding cipher state can be determined SHOULD
 handle it as a record which fails deprotection.
 
-Note that epoch values do not wrap. If a DTLS implementation would
-need to wrap the epoch value, it MUST terminate the connection.
+Epoch values are allowed to wrap. When the epoch value 2^16-1 is incremented,
+the new incremented epoch value is 4.
 
 The traffic key calculation is described in Section 7.3 of {{!TLS13}}.
 


### PR DESCRIPTION
Alternative solution to address issue #249 

This may be a simpler solution unless there are any security implications. DTLS 1.0 allowed epoch wrapping. DTLS 1.2 forbid epoch wrapping. I don't know the history behind this or if the reasons for forbidding epoch wrapping in DTLS 1.2 still apply to DTLS 1.3