### PR TITLE
Increase effective epoch width to 64 bits, keeping the serialized representation 16 bits wide

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -484,8 +484,8 @@ unpacked RecordNumber structure, as shown below:
     } RecordNumber;
 ~~~
 
-This 112-bit value is used in the ACK message. The low order 64 bits are used in
-the "record_sequence_number" input to the AEAD function.
+This 112-bit value is used in the ACK message. The low order 64 bits are used as
+the sequence number for reading and writing records; see {{TLS13, Section 5.3}}.
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
 encryption, see {{rne}}) is used as as the additional data value for the AEAD

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -484,8 +484,8 @@ unpacked RecordNumber structure, as shown below:
     } RecordNumber;
 ~~~
 
-This 64-bit value is used in the ACK message as well as in the "record_sequence_number"
-input to the AEAD function.
+This 112-bit value is used in the ACK message. The low order 64 bits are used in
+the "record_sequence_number" input to the AEAD function.
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
 encryption, see {{rne}}) is used as as the additional data value for the AEAD

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -313,8 +313,8 @@ also different from the DTLS 1.2 record layer.
 
 3. The DTLS epoch serialized in DTLSPlaintext is 2 octets long for compatibility
    with DTLS 1.2. However, this value is set as the least significant 2 octets
-   from the effective epoch of a connection, which is an 8 octet counter
-   incremented on every KeyUpdate. See {{seq-and-epoch}} for details.
+   of the epoch of a connection, which is an 8 octet counter incremented on every
+   KeyUpdate. See {{seq-and-epoch}} for details.
 
 4. The DTLSCiphertext structure has a variable length header.
 
@@ -356,7 +356,7 @@ legacy_record_version
   for the rationale for this.
 
 legacy_epoch
-: The least significant 2 bytes of the effective connection epoch value.
+: The least significant 2 bytes of the connection epoch value.
 
 unified_hdr:
 : The unified header (unified_hdr) is a structure of variable length, as shown in {{cid_hdr}}.
@@ -573,7 +573,7 @@ carried in the sequence_number field of the record.  Sequence numbers
 are maintained separately for each epoch, with each sequence_number
 initially being 0 for each epoch.
 
-The effective epoch number is initially zero and is incremented each time
+The epoch number is initially zero and is incremented each time
 keying material changes and a sender aims to rekey. More details
 are provided in {{dtls-epoch}}.
 

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -313,7 +313,7 @@ also different from the DTLS 1.2 record layer.
 
 3. The DTLS epoch serialized in DTLSPlaintext is 2 octets long for compatibility
    with DTLS 1.2. However, this value is set as the least significant 2 octets
-   of the epoch of a connection, which is an 8 octet counter incremented on every
+   of the connection epoch, which is an 8 octet counter incremented on every
    KeyUpdate. See {{seq-and-epoch}} for details.
 
 4. The DTLSCiphertext structure has a variable length header.
@@ -329,7 +329,7 @@ meaning of the fields is unchanged from previous TLS / DTLS versions.
     struct {
         ContentType type;
         ProtocolVersion legacy_record_version;
-        uint16 legacy_epoch = 0
+        uint16 epoch = 0
         uint48 sequence_number;
         uint16 length;
         opaque fragment[DTLSPlaintext.length];
@@ -355,7 +355,7 @@ legacy_record_version
   It MUST be ignored for all purposes. See {{TLS13}}; Appendix D.1
   for the rationale for this.
 
-legacy_epoch
+epoch
 : The least significant 2 bytes of the connection epoch value.
 
 unified_hdr:


### PR DESCRIPTION
Yet another alternative to #249. 

cc @emanjon @hannestschofenig 