### PR TITLE
Extended epoch like tls. Fixed #249

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -484,8 +484,8 @@ unpacked RecordNumber structure, as shown below:
     } RecordNumber;
 ~~~
 
-This 112-bit value is used in the ACK message. The low order 64 bits are used in
-the "record_sequence_number" input to the AEAD function.
+This 112-bit value is used in the ACK message. The low order 64 bits are used as
+the sequence number for reading and writing records; see {{TLS13, Section 5.3}}.
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
 encryption, see {{rne}}) is used as as the additional data value for the AEAD

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -484,8 +484,8 @@ unpacked RecordNumber structure, as shown below:
     } RecordNumber;
 ~~~
 
-This 64-bit value is used in the ACK message as well as in the "record_sequence_number"
-input to the AEAD function.
+This 112-bit value is used in the ACK message. The low order 64 bits are used in
+the "record_sequence_number" input to the AEAD function.
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
 encryption, see {{rne}}) is used as as the additional data value for the AEAD

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -2164,6 +2164,14 @@ Client                                             Server
 ~~~
 {: #dtls-key-update title="Example DTLS Key Update"}
 
+Implementations MUST NOT send KeyUpdates that would result
+in epochs of greater than or equal to 2^{48}-1. This limits
+the probability that a 128 bit key will be repeated during
+a connection. Note, however, that even if the key repeats,
+the IV is also independently generated. In order to allow
+future relaxation of this requirement, receiving implementations
+MUST NOT enforce this rule.
+
 
 # Connection ID Updates
 

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -314,7 +314,8 @@ also different from the DTLS 1.2 record layer.
 3. The DTLS epoch serialized in DTLSPlaintext is 2 octets long for compatibility
    with DTLS 1.2. However, this value is set as the least significant 2 octets
    of the connection epoch, which is an 8 octet counter incremented on every
-   KeyUpdate. See {{seq-and-epoch}} for details.
+   KeyUpdate. See {{seq-and-epoch}} for details. The sequence number is set to
+   be the low order 48 bits of the 64 bit sequence number.
 
 4. The DTLSCiphertext structure has a variable length header.
 
@@ -480,12 +481,11 @@ unpacked RecordNumber structure, as shown below:
 %%% Record Layer
     struct {
         uint64 epoch;
-        uint48 sequence_number;
+        uint64 sequence_number;
     } RecordNumber;
 ~~~
 
-This 112-bit value is used in the ACK message. The low order 64 bits are used as
-the sequence number for reading and writing records; see {{TLS13, Section 5.3}}.
+This 128-bit value is used in the ACK message. 
 
 The entire header value shown in {{hdr_examples}} (but prior to record number
 encryption, see {{rne}}) is used as as the additional data value for the AEAD
@@ -613,8 +613,9 @@ establish a new association, terminating the old association.
 
 When receiving protected DTLS records, the recipient does not
 have a full epoch or sequence number value in the record and so there is some
-opportunity for ambiguity.  Because the full epoch and sequence number
-are used to compute the per-record nonce, failure to reconstruct these
+opportunity for ambiguity.  Because the full sequence number
+is used to compute the per-record nonce and the epoch determines
+the keys, failure to reconstruct these
 values leads to failure to deprotect the record, and so implementations
 MAY use a mechanism of their choice to determine the full values.
 This section provides an algorithm which is comparatively simple

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1,4 +1,4 @@
-2^---
+---
 title: The Datagram Transport Layer Security (DTLS) Protocol Version 1.3
 abbrev: DTLS 1.3
 docname: draft-ietf-tls-dtls13-latest

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -313,8 +313,8 @@ also different from the DTLS 1.2 record layer.
 
 3. The DTLS epoch serialized in DTLSPlaintext is 2 octets long for compatibility
    with DTLS 1.2. However, this value is set as the least significant 2 octets
-   from the effective epoch of a connection, which is an 8 octet counter
-   incremented on every KeyUpdate. See {{seq-and-epoch}} for details.
+   of the epoch of a connection, which is an 8 octet counter incremented on every
+   KeyUpdate. See {{seq-and-epoch}} for details.
 
 4. The DTLSCiphertext structure has a variable length header.
 
@@ -356,7 +356,7 @@ legacy_record_version
   for the rationale for this.
 
 legacy_epoch
-: The least significant 2 bytes of the effective connection epoch value.
+: The least significant 2 bytes of the connection epoch value.
 
 unified_hdr:
 : The unified header (unified_hdr) is a structure of variable length, as shown in {{cid_hdr}}.
@@ -573,7 +573,7 @@ carried in the sequence_number field of the record.  Sequence numbers
 are maintained separately for each epoch, with each sequence_number
 initially being 0 for each epoch.
 
-The effective epoch number is initially zero and is incremented each time
+The epoch number is initially zero and is incremented each time
 keying material changes and a sender aims to rekey. More details
 are provided in {{dtls-epoch}}.
 

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -313,7 +313,7 @@ also different from the DTLS 1.2 record layer.
 
 3. The DTLS epoch serialized in DTLSPlaintext is 2 octets long for compatibility
    with DTLS 1.2. However, this value is set as the least significant 2 octets
-   of the epoch of a connection, which is an 8 octet counter incremented on every
+   of the connection epoch, which is an 8 octet counter incremented on every
    KeyUpdate. See {{seq-and-epoch}} for details.
 
 4. The DTLSCiphertext structure has a variable length header.
@@ -329,7 +329,7 @@ meaning of the fields is unchanged from previous TLS / DTLS versions.
     struct {
         ContentType type;
         ProtocolVersion legacy_record_version;
-        uint16 legacy_epoch = 0
+        uint16 epoch = 0
         uint48 sequence_number;
         uint16 length;
         opaque fragment[DTLSPlaintext.length];
@@ -355,7 +355,7 @@ legacy_record_version
   It MUST be ignored for all purposes. See {{TLS13}}; Appendix D.1
   for the rationale for this.
 
-legacy_epoch
+epoch
 : The least significant 2 bytes of the connection epoch value.
 
 unified_hdr:

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -315,7 +315,9 @@ also different from the DTLS 1.2 record layer.
    with DTLS 1.2. However, this value is set as the least significant 2 octets
    of the connection epoch, which is an 8 octet counter incremented on every
    KeyUpdate. See {{seq-and-epoch}} for details. The sequence number is set to
-   be the low order 48 bits of the 64 bit sequence number.
+   be the low order 48 bits of the 64 bit sequence number. Plaintext records
+   MUST NOT be sent with sequence numbers that would exceedd 2^48-1, so the
+   upper 16 bits will always be 0.
 
 4. The DTLSCiphertext structure has a variable length header.
 
@@ -492,6 +494,8 @@ encryption, see {{rne}}) is used as as the additional data value for the AEAD
 function. For instance, if the minimal variant is used,
 the AAD is 2 octets long. Note that this design is different from the additional data
 calculation for DTLS 1.2 and for DTLS 1.2 with Connection ID.
+In DTLS 1.3 the 64-bit sequence_number is used as the sequence number for
+the AEAD computation; unlike DTLS 1.2, the epoch is not included. 
 
 ## Demultiplexing DTLS Records
 

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1,4 +1,4 @@
----
+2^---
 title: The Datagram Transport Layer Security (DTLS) Protocol Version 1.3
 abbrev: DTLS 1.3
 docname: draft-ietf-tls-dtls13-latest
@@ -316,7 +316,7 @@ also different from the DTLS 1.2 record layer.
    of the connection epoch, which is an 8 octet counter incremented on every
    KeyUpdate. See {{seq-and-epoch}} for details. The sequence number is set to
    be the low order 48 bits of the 64 bit sequence number. Plaintext records
-   MUST NOT be sent with sequence numbers that would exceedd 2^48-1, so the
+   MUST NOT be sent with sequence numbers that would exceed 2^48-1, so the
    upper 16 bits will always be 0.
 
 4. The DTLSCiphertext structure has a variable length header.
@@ -609,9 +609,6 @@ epoch and keying material as the original transmission.
 
 Implementations MUST either abandon an association or re-key prior to
 allowing the sequence number to wrap.
-
-Implementations MUST NOT allow the epoch to wrap, but instead MUST
-establish a new association, terminating the old association.
 
 ### Reconstructing the Sequence Number and Epoch {#reconstructing}
 
@@ -2164,13 +2161,16 @@ Client                                             Server
 ~~~
 {: #dtls-key-update title="Example DTLS Key Update"}
 
-Implementations MUST NOT send KeyUpdates that would result
-in epochs of greater than or equal to 2^{48}-1. This limits
-the probability that a 128 bit key will be repeated during
-a connection. Note, however, that even if the key repeats,
-the IV is also independently generated. In order to allow
-future relaxation of this requirement, receiving implementations
-MUST NOT enforce this rule.
+With a 128-bit key as in AES-256, rekeying 2^64 times has a high
+probability of key reuse within a given connection. Note that even if
+the key repeats, the IV is also independently generated. In order to
+provide an extra margin of security, sending implementations MUST NOT
+allow the epoch to exceed 2^48-1. In order to allow this value to
+be changed later, receiving implementations MUST NOT
+enforce this rule. If a sending implementation receives a KeyUpdate
+with request_update set to "update_requested", it MUST NOT send
+its own KeyUpdate if that would cause it to exceed these limits.
+
 
 
 # Connection ID Updates


### PR DESCRIPTION
Yet another attempt to fix #249.

This builds on Chris's PR but just omits the epoch entirely from the AEAD nonce calculation. This is more consistent with TLS and doesn't require special case reasoning about why we only need to build in the bottom 16 bits. This relies entirely on the keys being different. Needs analysis.