### PR TITLE
Change the transcript to use TLS 1.3-style Handshake messages. Fixes

### DIFF
--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1146,7 +1146,7 @@ message loss, reordering, and message fragmentation.
 In DTLS 1.3, the message transcript is computed over the original
 TLS 1.3-style Handshake messages without the message_seq,
 fragment_offset, and fragment_length values. Note that this is
-a change from DTLS 1.2 where which those values were included
+a change from DTLS 1.2 where those values were included
 in the transcript.
 
 The first message each side transmits in each association always has

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1263,7 +1263,7 @@ avoiding IP fragmentation.
 When transmitting the handshake message, the sender divides the
 message into a series of N contiguous data ranges. The ranges MUST NOT
 overlap.  The sender then creates N DTLSHandshake messages, all with the
-same message_seq value asssociated the original handshake message.  Each new
+same message_seq value associated with the original handshake message.  Each new
 message is labeled with the fragment_offset (the number of bytes
 contained in previous fragments) and the fragment_length (the length
 of this fragment).  The length field in all messages is the same as

--- a/draft-ietf-tls-dtls13.md
+++ b/draft-ietf-tls-dtls13.md
@@ -1275,7 +1275,7 @@ MUST be delivered in a single UDP datagram.
 When a DTLS implementation receives a handshake message fragment corresponding
 to the next expected handshake message sequence number, it
 MUST process it, either by buffering it until it has the entire handshake message
-or by processing any in-order portions of the message
+or by processing any in-order portions of the message.
 The transcript consists of complete TLS Handshake messages (reassembled
 as necessary). Note that this requires removing the message_seq,
 fragment_offset, and fragment_length fields to create the Handshake


### PR DESCRIPTION
This makes the handshake the same as TLS 1.3 (modulo the version
numbers, which are conveniently different.

