### PR TITLE
Attempt to rewrite record handling

### DIFF
--- a/draft-ietf-tls-rfc9147bis.md
+++ b/draft-ietf-tls-rfc9147bis.md
@@ -870,7 +870,7 @@ the record layer.  This includes:
 
 * Records that cannot be demultiplexed as DTLS records.
 
-Records that are successfully decoded and decrypted can be assumed to be
+Records that are successfully decoded and deprotected can be assumed to be
 valid and errors in the contents of records MUST be regarded as originating
 from the peer.  Fatal alerts can be generated based on the content of
 records.  This includes all the unprotected records exchanged as part of the
@@ -881,10 +881,6 @@ caused by damage to handshake messages carried in unprotected records.
 
 In general, invalid records SHOULD be silently discarded, thus preserving
 the association; however, an error MAY be logged for diagnostic purposes.
-
-Generating fatal alerts is NOT RECOMMENDED for unreliable transports, both to
-increase the reliability of DTLS service and to avoid the risk of spoofing
-attacks sending traffic to unrelated third parties.
 
 If DTLS is being carried over a transport that is resistant to
 forgery (e.g., SCTP with SCTP-AUTH {{RFC6083}}), then it is safer to send alerts

--- a/draft-ietf-tls-rfc9147bis.md
+++ b/draft-ietf-tls-rfc9147bis.md
@@ -845,29 +845,30 @@ record has been deprotected  successfully.
 
 ### Handling Invalid Records
 
-Unlike TLS, DTLS can be resilient when receiving invalid records (e.g.,
-invalid formatting, length, MAC, etc.).
+Unlike TLS, DTLS can be resilient when receiving records that cannot be
+processed at the record layer.
 
-When receiving a record that is invalid, endpoints SHOULD discard the record
-rather than generating a fatal alert. This includes only the construction of
-records and the AEAD protection on the record (if any), not the contents of
-a record that is successfully decrypted.  This includes:
+An endpoint MUST discard a record, without updating handshake state, ACK state,
+retransmission state, or replay windows, when the record cannot be processed at
+the record layer.  This includes:
 
-* Records that contain invalid header values.  For instance, records with
+* Records with invalid header values.  For instance, records with
   invalid values for fields other than `fragment` in `DTLSPlaintext` or
   `DTLSCiphertext`; see {{dtls-record}}.
 
-* Records where length does not match the length of available data. For
+* Records whose length is inconsistent with the remaining datagram contents. For
   instance, where the length indicates a length longer than what remains in
   a UDP datagram.
 
 * Records with an epoch that is not currently being accepted.
 
-* Records where authenticated encryption protection cannot be removed
+* Records where AEAD protection cannot be removed
   successfully.
 
-* Records that contain an invalid inner content type or unterminated
-  padding; see `DTLSInnerPlaintext` in {{dtls-record}}}.
+* Records with an invalid inner content type or invalid; and
+  padding; see `DTLSInnerPlaintext` in {{dtls-record}}.
+
+* Records that cannot be demultiplexed as DTLS records.
 
 Records that are successfully decoded and decrypted can be assumed to be
 valid and errors in the contents of records MUST be regarded as originating


### PR DESCRIPTION
This takes the feedback in #283 and attempts to restructure the section to be clearer about what invalid record processing means.  And what to do if it happens.

I did not take @dennisjackson's point about application data interleaved between two handshake records in the same datagram.  That seemed a bit esoteric, so I turned it into something less specific.  That might mean that sometimes people will miss that very specific corner case of bad peer.

Many more paragraphs, but a lot of the text, aside from the list and the one paragraph before and two paragraphs after it, is just copied and pasted from the existing walloftext.

Closes #283.